### PR TITLE
DefaultEntityResolver: use the HTML5 entities as fallback if no subset is found in getExternalSubset()

### DIFF
--- a/junit/io/sf/carte/doc/xml/dtd/DefaultEntityResolverTest.java
+++ b/junit/io/sf/carte/doc/xml/dtd/DefaultEntityResolverTest.java
@@ -45,9 +45,6 @@ public class DefaultEntityResolverTest {
 		Reader re = isrc.getCharacterStream();
 		assertNotNull(re);
 		re.close();
-		//
-		isrc = resolver.getExternalSubset("foo", null);
-		assertNull(isrc);
 		// SVG
 		isrc = resolver.getExternalSubset("svg", null);
 		assertNotNull(isrc);
@@ -56,6 +53,24 @@ public class DefaultEntityResolverTest {
 		re = isrc.getCharacterStream();
 		assertNotNull(re);
 		re.close();
+	}
+
+	@Test
+	public void getExternalSubsetStringStringUnknownSubset() throws SAXException, IOException {
+		InputSource isrc = resolver.getExternalSubset("foo", null);
+		assertNotNull(isrc);
+		assertNull(isrc.getPublicId());
+		assertNull(isrc.getSystemId());
+		Reader re = isrc.getCharacterStream();
+		assertNotNull(re);
+		char[] cbuf = new char[40];
+		try {
+			re.read(cbuf);
+		} finally {
+			re.close();
+		}
+		String sbuf = new String(cbuf);
+		assertEquals("<!ENTITY Tab \"&#x9;\"><!ENTITY NewLine \"&", sbuf);
 	}
 
 	@Test

--- a/junit/io/sf/carte/doc/xml/dtd/StackedEntityResolverTest.java
+++ b/junit/io/sf/carte/doc/xml/dtd/StackedEntityResolverTest.java
@@ -45,8 +45,24 @@ public class StackedEntityResolverTest {
 		Reader re = isrc.getCharacterStream();
 		assertNotNull(re);
 		re.close();
-		isrc = stackedResolver.getExternalSubset("foo", null);
-		assertNull(isrc);
+	}
+
+	@Test
+	public void getExternalSubsetStringStringUnknownSubset() throws SAXException, IOException {
+		InputSource isrc = stackedResolver.getExternalSubset("foo", null);
+		assertNotNull(isrc);
+		assertNull(isrc.getPublicId());
+		assertNull(isrc.getSystemId());
+		Reader re = isrc.getCharacterStream();
+		assertNotNull(re);
+		char[] cbuf = new char[40];
+		try {
+			re.read(cbuf);
+		} finally {
+			re.close();
+		}
+		String sbuf = new String(cbuf);
+		assertEquals("<!ENTITY Tab \"&#x9;\"><!ENTITY NewLine \"&", sbuf);
 	}
 
 	@Test

--- a/junit/io/sf/carte/doc/xml/dtd/StackedEntityResolverTest2.java
+++ b/junit/io/sf/carte/doc/xml/dtd/StackedEntityResolverTest2.java
@@ -45,8 +45,24 @@ public class StackedEntityResolverTest2 {
 		Reader re = isrc.getCharacterStream();
 		assertNotNull(re);
 		re.close();
-		isrc = stackedResolver.getExternalSubset("foo", null);
-		assertNull(isrc);
+	}
+
+	@Test
+	public void getExternalSubsetStringStringUnknownSubset() throws SAXException, IOException {
+		InputSource isrc = stackedResolver.getExternalSubset("foo", null);
+		assertNotNull(isrc);
+		assertNull(isrc.getPublicId());
+		assertNull(isrc.getSystemId());
+		Reader re = isrc.getCharacterStream();
+		assertNotNull(re);
+		char[] cbuf = new char[40];
+		try {
+			re.read(cbuf);
+		} finally {
+			re.close();
+		}
+		String sbuf = new String(cbuf);
+		assertEquals("<!ENTITY Tab \"&#x9;\"><!ENTITY NewLine \"&", sbuf);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #3.